### PR TITLE
fix UBs related to order of execution and signed integer overflow

### DIFF
--- a/apps/microbench/README.md
+++ b/apps/microbench/README.md
@@ -51,7 +51,7 @@ CPU正确性和性能测试用基准程序。对AbstractMachine的要求：
 虽然klib中提供了一些函数，但使用它们可能会导致在不同平台上的性能不准确。
 
 * `bench_memcpy(void *dst, const void *src, size_t n)`: 内存复制。
-* `bench_srand(int seed)`：用seed初始化随机数种子。
+* `bench_srand(uint seed)`：用seed初始化随机数种子。
 * `bench_rand()`：返回一个0..32767之间的随机数。
 * `bench_alloc`/`bench_free`：内存分配/回收。目前回收是空操作。
 

--- a/apps/microbench/include/benchmark.h
+++ b/apps/microbench/include/benchmark.h
@@ -103,8 +103,8 @@ void bench_free(void *ptr);
 void bench_reset();
 
 // random number generator
-void bench_srand(int32_t seed);
-int32_t bench_rand(); // return a random number between 0..32767
+void bench_srand(uint32_t seed);
+uint32_t bench_rand(); // return a random number between 0..32767
 
 // checksum
 uint32_t checksum(void *start, void *end);

--- a/apps/microbench/src/bench.c
+++ b/apps/microbench/src/bench.c
@@ -131,28 +131,27 @@ void bench_reset() {
   start = (char*)_heap.start;
 }
 
-static int32_t seed = 1;
+static uint32_t seed = 1;
 
-void bench_srand(int32_t _seed) {
+void bench_srand(uint32_t _seed) {
   seed = _seed & 0x7fff;
 }
 
-int32_t bench_rand() {
-  seed = (seed * (int32_t)214013L + (int32_t)2531011L);
+uint32_t bench_rand() {
+  seed = (seed * (uint32_t)214013L + (uint32_t)2531011L);
   return (seed >> 16) & 0x7fff;
 }
 
 // FNV hash
 uint32_t checksum(void *start, void *end) {
-  const int32_t x = 16777619;
-  int32_t hash = 2166136261u;
+  const uint32_t x = 16777619;
+  uint32_t h1 = 2166136261u;
   for (uint8_t *p = (uint8_t*)start; p + 4 < (uint8_t*)end; p += 4) {
-    int32_t h1 = hash;
     for (int i = 0; i < 4; i ++) {
       h1 = (h1 ^ p[i]) * x;
     }
-    hash = h1;
   }
+  int32_t hash = (uint32_t)h1;
   hash += hash << 13;
   hash ^= hash >> 7;
   hash += hash << 3;

--- a/apps/microbench/src/qsort/qsort.c
+++ b/apps/microbench/src/qsort/qsort.c
@@ -9,7 +9,9 @@ void bench_qsort_prepare() {
 
   data = bench_alloc(N * sizeof(int));
   for (int i = 0; i < N; i ++) {
-    data[i] = (bench_rand() << 16) | bench_rand();
+    int a = bench_rand();
+    int b = bench_rand();
+    data[i] = (a << 16) | b;
   }
 }
 


### PR DESCRIPTION
There are some UBs that makes microbench fails on gcc 8.2:
- Signed interger overflow: (which is the root cause of this issue #1)
``` 
int32_t h1 = hash;
for (int i = 0; i < 4; i ++) {
   h1 = (h1 ^ p[i]) * x;
}
```
- Undefined order of execution: (potential bug source, no report of effect yet)
```
data[i] = (bench_rand() << 16) | bench_rand(); // bench_rand() will change the state!
```
Please fix them ASAP. 