### PR TITLE
native,vme: do not switch address space while c->prot == NULL

### DIFF
--- a/am/arch/native/src/vme.c
+++ b/am/arch/native/src/vme.c
@@ -38,7 +38,7 @@ void get_cur_as(_Context *c) {
 
 void _switch(_Context *c) {
   _Protect *p = c->prot;
-  if (p == cur_as) return;
+  if (p == NULL || p == cur_as) return;
   PageMap *pp;
 
   if (cur_as != NULL) {


### PR DESCRIPTION
* this can keep vme code in irq_handle() even vme is not enabled